### PR TITLE
busybox: libarchive: Fix matchpathcon_init use of libselinux

### DIFF
--- a/archival/libarchive/data_extract_all.c
+++ b/archival/libarchive/data_extract_all.c
@@ -15,7 +15,7 @@ void FAST_FUNC data_extract_all(archive_handle_t *archive_handle)
 #if ENABLE_FEATURE_TAR_SELINUX
 	char *sctx = archive_handle->tar__sctx[PAX_NEXT_FILE];
 #ifdef __BIONIC__
-	matchpathcon_init(NULL);
+	matchpathcon_init("/file_contexts");
 #endif
 	if (!sctx)
 		sctx = archive_handle->tar__sctx[PAX_GLOBAL];


### PR DESCRIPTION
 * Provide the /file_contexts path to libselinux

 * Avoids a SIGSEGV upon cpio extraction due to a NULL
    file_contexts input, which fails down the layers
    of libselinux upon strdup of the path

Change-Id: Ic8a8e8a461c0433144af15d48d2ce7299be84152
Signed-off-by: Adrian DC <radian.dc@gmail.com>